### PR TITLE
Case Insensitive keywords

### DIFF
--- a/grammars/htaccess.cson
+++ b/grammars/htaccess.cson
@@ -84,7 +84,7 @@
         'name': 'keyword.definition.auth.htaccess'
       }
       {
-        'match': '\\b(Allow|Deny|Order|Access-Control-Allow-Origin|Accept-Encoding)\\b'
+        'match': '\\b((?i:Allow|Deny|Order)|Access-Control-Allow-Origin|Accept-Encoding)\\b'
         'name': 'constant.keyword.access.htaccess'
       }
       {


### PR DESCRIPTION
Updated pattern for constant.keyword.access.htaccess to accept some lowercase keywords too.
